### PR TITLE
Update `package.json` to export types declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "description": "Find books by ISBN",
   "exports": "./src/index.js",
+  "types": "./src/index.d.ts",
   "type": "module",
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
Hey there,

Thanks for restarting maintenance on this library! I happen to want to use it for [a project I'm building](https://github.com/Candid-Engineering/books-db): an app to use a barcode scanner to keep track of a book collection. When I imported `@library-pals/isbn`, vscode yelled at me about missing module/types:

![isbn-type-error](https://github.com/library-pals/isbn/assets/35267/b789ef15-1c04-40f1-ad27-cd49cea9f449)

This Pull Request follows the [typescript recommendation](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) for publishing the `.d.ts` you've generated by adding a `types` field to `package.json`.