### PR TITLE
Export types via `exports` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "@library-pals/isbn",
   "version": "1.4.0",
   "description": "Find books by ISBN",
-  "exports": "./src/index.js",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./src/index.js"
+    }
+  },
   "types": "./types/index.d.ts",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
Fix #31—although increases overall compatibility with some package managers—doesn't fix issue #29. The only thing that seemed to solve it for me was explicitly exporting the types in the `exports` field by replacing it to be the following:

```json
"exports": {
  ".": {
    "types": "./types/index.d.ts",
    "default": "./src/index.js"
  }
},
```

This I'm _pretty_ sure won't break anything, but I'm no expert at this.