### PR TITLE
Fix google thumbnail size

### DIFF
--- a/src/providers/google.js
+++ b/src/providers/google.js
@@ -143,11 +143,11 @@ export async function getVolume(id) {
 function getLargestThumbnail(imageLinks) {
   const sizes = [
     "extraLarge",
+    "smallThumbnail",
     "large",
     "medium",
     "small",
     "thumbnail",
-    "smallThumbnail",
   ];
 
   if (!imageLinks) return;


### PR DESCRIPTION
[According to this sample response](https://developers.google.com/books/docs/v1/using\#response_1) the `smallThumbnail` size has a `zoom` value of 5, making it the second largest available—not the smallest as it's currently treated.

This solves the issue I'm facing where a book will only have `smallThumbnail` and `thumbnail`, but the library will provide me with `thumbnail` thinking it's the largest of the two. 